### PR TITLE
Give elements unique names to simplify view updates.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -79,22 +79,19 @@ class ProviderDynamicWeatherTest extends UrlbarProvider {
     let daysOfWeek = [];
     for (let day = 0; day < 5; day++) {
       daysOfWeek.push({
-        name: "day",
+        name: `day${day}`,
         tag: "div",
-        attributes: {
-          dayNumber: `${day}`,
-        },
         children: [
           {
-            name: "dayofweek",
+            name: `dayOfWeek${day}`,
             tag: "span",
           },
           {
-            name: "icon",
+            name: `dayIcon${day}`,
             tag: "img",
           },
           {
-            name: "temperature",
+            name: `dayTemperature${day}`,
             tag: "span",
           },
         ],
@@ -137,15 +134,15 @@ class ProviderDynamicWeatherTest extends UrlbarProvider {
             tag: "div",
             children: [
               {
-                name: "icon",
+                name: "currentIcon",
                 tag: "img",
               },
               {
-                name: "temperature",
+                name: "currentTemperature",
                 tag: "span",
               },
               {
-                name: "units",
+                name: "currentUnits",
                 tag: "span",
               },
             ],
@@ -223,49 +220,49 @@ class ProviderDynamicWeatherTest extends UrlbarProvider {
   // Updates the result's view.
   getViewUpdate(result) {
     let viewUpdate = {
-      "info > .dynamicWeather-location": {
+      location: {
         textContent: result.payload.locationName,
       },
-      "info > .dynamicWeather-forecastTime": {
+      forecastTime: {
         textContent: result.payload.forecastTime,
       },
-      "info > .dynamicWeather-currentConditions": {
+      currentConditions: {
         textContent: result.payload.current.conditions,
       },
-      "info > .dynamicWeather-provider": {
+      provider: {
         textContent: result.payload.providerName,
       },
-      "current > .dynamicWeather-icon": {
+      currentIcon: {
         attributes: {
           src: result.payload.current.icon,
         },
       },
-      "current > .dynamicWeather-temperature": {
+      currentTemperature: {
         textContent: result.payload.current.temperature,
       },
-      "current > .dynamicWeather-units": {
+      currentUnits: {
         textContent: result.payload.units == "us" ? "°F" : "°C",
       },
     };
 
     for (let day = 0; day < 5; day++) {
       if (!result.payload.daily[day]) {
-        viewUpdate[`daysContainer > .dynamicWeather-day[dayNumber='${day}']`] = {
+        viewUpdate[`day${day}`] = {
           style: {
             display: "none",
           }
         };
         continue;
       }
-      viewUpdate[`daysContainer > .dynamicWeather-day[dayNumber='${day}'] > .dynamicWeather-dayofweek`] = {
+      viewUpdate[`dayOfWeek${day}`] = {
         textContent: result.payload.daily[day].dayOfWeek,
       };
-      viewUpdate[`daysContainer > .dynamicWeather-day[dayNumber='${day}'] > .dynamicWeather-icon`] = {
+      viewUpdate[`dayIcon${day}`] = {
         attributes: {
           src: result.payload.daily[day].icon,
         },
       };
-      viewUpdate[`daysContainer > .dynamicWeather-day[dayNumber='${day}'] > .dynamicWeather-temperature`] = {
+      viewUpdate[`dayTemperature${day}`] = {
         textContent:
           result.payload.daily[day].temperatureHigh +
           "° / " +

--- a/src/data/style.css
+++ b/src/data/style.css
@@ -28,7 +28,12 @@
   margin: 6px;
 }
 
-.dynamicWeather-icon {
+.dynamicWeather-dayIcon0,
+.dynamicWeather-dayIcon1,
+.dynamicWeather-dayIcon2,
+.dynamicWeather-dayIcon3,
+.dynamicWeather-dayIcon4,
+.dynamicWeather-currentIcon {
   -moz-context-properties: stroke;
   stroke: currentColor;
 }
@@ -55,16 +60,16 @@
   align-items: center;
 }
 
-.dynamicWeather-current  > .dynamicWeather-icon {
+.dynamicWeather-current > .dynamicWeather-currentIcon {
   min-width: 3.5em;
   margin-inline-end: 20px;
 }
 
-.dynamicWeather-current > .dynamicWeather-temperature {
+.dynamicWeather-current > .dynamicWeather-currentTemperature {
   font-size: 3.5em;
 }
 
-.dynamicWeather-current > .dynamicWeather-units {
+.dynamicWeather-current > .dynamicWeather-currentUnits {
   font-size: 1.5em;
   margin-bottom: 0.75em;
 }
@@ -76,19 +81,11 @@
   /*! overflow: hidden; */
 }
 
-@media screen and (max-width: 700px) {
-  .dynamicWeather-day:last-child {
-    display: none;
-  }
-}
-
-@media screen and (max-width: 642px) {
-  .dynamicWeather-day:nth-last-child(2) {
-    display: none;
-  }
-}
-
-.dynamicWeather-day {
+.dynamicWeather-day0,
+.dynamicWeather-day1,
+.dynamicWeather-day2,
+.dynamicWeather-day3,
+.dynamicWeather-day4 {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -98,10 +95,30 @@
   padding-inline: 8px;
 }
 
-.dynamicWeather-day > .dynamicWeather-dayofweek {
+@media screen and (max-width: 700px) {
+  .dynamicWeather-day4 {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 642px) {
+  .dynamicWeather-day3 {
+    display: none;
+  }
+}
+
+.dynamicWeather-dayOfWeek0,
+.dynamicWeather-dayOfWeek1,
+.dynamicWeather-dayOfWeek2,
+.dynamicWeather-dayOfWeek3,
+.dynamicWeather-dayOfWeek4 {
   font-size: 1.2em;
 }
 
-.dynamicWeather-day > .dynamicWeather-icon {
+dynamicWeather-dayIcon0,
+dynamicWeather-dayIcon1,
+dynamicWeather-dayIcon2,
+dynamicWeather-dayIcon3,
+dynamicWeather-dayIcon4 {
   min-width: 2.2em;
 }


### PR DESCRIPTION
The trade-off is it complicates the CSS a little. As a further improvement,
there could be another property in view templates called `className` or
`classes`. In this case, we'd set an "icon" className on all the icon elements,
a "day" className on all the day elements, and a "dayOfWeek" class name on all
the dayOfWeek elements. Then we could specify those class names in the CSS
instead of having to repeat ourselves.