### PR TITLE
No bug - Fix various weather result nits.

### DIFF
--- a/src/data/style.css
+++ b/src/data/style.css
@@ -27,11 +27,17 @@
   align-items: center !important;
 }
 
-.urlbarView-dynamic-dynamicWeather-icon {
-  height: 44px;
+.urlbarView-row[dynamicType=dynamicWeather] > .urlbarView-row-inner > .urlbarView-no-wrap > .urlbarView-favicon {
+  /* Override height on .urlbarView-favicon. */
+  height: 44px !important;
   max-width: 100%;
-  margin-inline-end: 4px;
-  -moz-context-properties: fill;
+}
+
+@media (min-resolution: 2dppx) {
+  .urlbarView-row[dynamicType=dynamicWeather] > .urlbarView-row-inner > .urlbarView-no-wrap > .urlbarView-favicon {
+    /* Override transform on .urlbarView-favicon since we want the icon and the text to be vertically centered. */
+    transform: none !important;
+  }
 }
 
 .urlbarView-dynamic-dynamicWeather-textContent {

--- a/tests/tests/browser/browser_weather_queries.js
+++ b/tests/tests/browser/browser_weather_queries.js
@@ -46,12 +46,15 @@ add_task(async function basic() {
     ["weather at new york", true],
     ["weather at", false],
     ["new york weather", true],
+    ["new york      weather", true],
+    ["weather new york", true],
     ["weather", false],
     ["new york forecast", true],
     ["forecast", false],
     ["toronto forecast", true],
     // We wait until the place name is three characters long.
     ["weather in ny", false],
+    ["NEW YORK WEATHER", true],
   ];
   await withAddon(async () => {
     const storageConn = await getExtensionStorage();


### PR DESCRIPTION
These are just small things I noticed while working on the tests that didn't really deserve their own bug.

Included changes:
- Location strings are trimmed and converted to lower case.
- We now allow searches for "weather <place name>"
- The className property on the icon has been updated from `urlbarView-icon` to `urlbarView-favicon`, matching the actual in-tree class name.
- The className change required a handful of CSS changes.
- Removed a duplicate `_currentLocationString` setter.
- Renamed `CachedWeatherResult to `CachedWeatherData` to avoid confusion with `UrlbarResult`s.
- Changed references to "current" throughout to "weather". The "current" name was a holdover from when there was both current weather and forecast weather.
- AccuWeather returns both location and weather data as arrays. Previously we were accessing the first element in the weather array from the `CachedWeatherResult.current()` getter and the first element in the location array from `getLocationDataFromQuery`. This patch standardizes them so the first element is split out when the data is fetched in both cases (i.e., we access the first weather element in `getWeatherData`). I decided on this instead of accessing the first location element in `CachedWeatherData.location` to both cache less data and to add more flexibility if we ever want a more sophisticated approach (e.g. using the location nearest the user instead of the top-ranked one).